### PR TITLE
Add photonvision init stuff

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import org.photonvision.PhotonCamera;
 
 public class Robot extends TimedRobot {
   private Command m_autonomousCommand;
@@ -17,6 +18,11 @@ public class Robot extends TimedRobot {
 
   private final boolean UseLimelight = false;
 
+  // Placeholder values, to be determined from web UI
+  final int NotePipelineIndex = 1;
+  final int APrilTagPipelineIndex = 2;
+  PhotonCamera = new PhotonCamera("arducam");
+  
   @Override
   public void robotInit() {
     m_robotContainer = new RobotContainer();


### PR DESCRIPTION
It will throw an error until "arducam" is replaced with the actual camera name in the photonvision web UI and I fix the networking, because at the moment I think there is a problem with the way the Orange Pi is configured.